### PR TITLE
Failed dependency blocks running of job

### DIFF
--- a/src/lib/__tests__/deployer.spec.ts
+++ b/src/lib/__tests__/deployer.spec.ts
@@ -36,7 +36,7 @@ describe('Deployer', () => {
   beforeEach(() => {
     // Clear all mocks
     jest.clearAllMocks()
-    
+
     // Setup mock networks
     mockNetwork1 = { name: 'mainnet', chainId: 1, rpcUrl: 'https://eth.rpc' }
     mockNetwork2 = { name: 'polygon', chainId: 137, rpcUrl: 'https://polygon.rpc' }
@@ -166,7 +166,7 @@ describe('Deployer', () => {
     describe('happy paths', () => {
       it('should successfully run a simple deployment', async () => {
         const deployer = new Deployer(deployerOptions)
-        
+
         await deployer.run()
 
         // Verify the flow
@@ -186,18 +186,18 @@ describe('Deployer', () => {
           if (jobName === 'job2') return new Set(['job1'])
           return new Set()
         })
-        
+
         const options: DeployerOptions = {
           ...deployerOptions,
           runJobs: ['job2'] // This should also include job1 due to dependency
         }
-        
+
         const deployer = new Deployer(options)
         await deployer.run()
 
         // Should execute job1 (dependency) and job2, but not job3
         expect(mockEngine.executeJob).toHaveBeenCalledTimes(4) // 2 jobs × 2 networks
-        
+
         // Verify it was called with the right jobs
         const executedJobs = mockEngine.executeJob.mock.calls.map(call => call[0].name)
         expect(executedJobs).toContain('job1')
@@ -210,12 +210,12 @@ describe('Deployer', () => {
           ...deployerOptions,
           runOnNetworks: [1] // Only mainnet
         }
-        
+
         const deployer = new Deployer(options)
         await deployer.run()
 
         expect(mockEngine.executeJob).toHaveBeenCalledTimes(3) // 3 jobs × 1 network
-        
+
         // Verify all calls were with mainnet
         const usedNetworks = MockExecutionContext.mock.calls.map(call => call[0])
         expect(usedNetworks).toHaveLength(3)
@@ -231,7 +231,7 @@ describe('Deployer', () => {
         // job3 has only_networks: [1], so should only run on mainnet
         const job3Calls = mockEngine.executeJob.mock.calls.filter(call => call[0].name === 'job3')
         expect(job3Calls).toHaveLength(1) // Only on mainnet
-        
+
         // Verify it was called with mainnet (check the MockExecutionContext calls)
         const contextCallsForJob3 = MockExecutionContext.mock.calls.filter((_, index) => {
           const engineCall = mockEngine.executeJob.mock.calls[index]
@@ -246,7 +246,7 @@ describe('Deployer', () => {
           name: 'job-skip-polygon',
           skip_networks: [137] // Skip polygon
         }
-        
+
         mockLoader.jobs.set('job-skip-polygon', jobWithSkipNetworks)
         mockGraph.getExecutionOrder.mockReturnValue(['job-skip-polygon'])
 
@@ -268,13 +268,13 @@ describe('Deployer', () => {
 
         // Verify output files (flat)
         expect(mockFs.writeFile).toHaveBeenCalledTimes(3)
-        
+
         // Check job1 output file (flat path)
         const job1OutputCall = mockFs.writeFile.mock.calls.find(call =>
           call[0] === '/test/project/output/job1.json'
         )
         expect(job1OutputCall).toBeDefined()
-        
+
         const job1Content = JSON.parse(job1OutputCall![1] as string)
         expect(job1Content).toMatchObject({
           jobName: 'job1',
@@ -349,11 +349,11 @@ describe('Deployer', () => {
             { name: 'other-action', template: 'template1', arguments: {} } // no output flag
           ]
         }
-        
+
         mockLoader.jobs.clear()
         mockLoader.jobs.set('job-with-output-flags', jobWithOutputFlags)
         mockGraph.getExecutionOrder.mockReturnValue(['job-with-output-flags'])
-        
+
         // Mock context to return outputs from all actions
         mockContext.getOutputs.mockReturnValue(new Map<string, any>([
           ['deploy-action.address', '0xdeployaddress'],
@@ -367,14 +367,14 @@ describe('Deployer', () => {
 
         // Verify output file was written
         expect(mockFs.writeFile).toHaveBeenCalledTimes(1)
-        
+
         const outputCall = mockFs.writeFile.mock.calls[0]
         expect(outputCall[0]).toBe('/test/project/output/job-with-output-flags.json')
-        
+
         const outputContent = JSON.parse(outputCall[1] as string)
         expect(outputContent.networks).toHaveLength(1)
         expect(outputContent.networks[0].status).toBe('success')
-        
+
         // Should only include outputs from deploy-action (output: true)
         // Should NOT include verify-action (output: false) or other-action (no flag)
         expect(outputContent.networks[0].outputs).toEqual({
@@ -394,11 +394,11 @@ describe('Deployer', () => {
             { name: 'action2', template: 'template1', arguments: {}, output: false }
           ]
         }
-        
+
         mockLoader.jobs.clear()
         mockLoader.jobs.set('job-without-output-flags', jobWithoutOutputFlags)
         mockGraph.getExecutionOrder.mockReturnValue(['job-without-output-flags'])
-        
+
         // Mock context to return outputs from all actions
         mockContext.getOutputs.mockReturnValue(new Map<string, any>([
           ['action1.result', 'result1'],
@@ -410,10 +410,10 @@ describe('Deployer', () => {
 
         // Verify output file was written
         expect(mockFs.writeFile).toHaveBeenCalledTimes(1)
-        
+
         const outputCall = mockFs.writeFile.mock.calls[0]
         const outputContent = JSON.parse(outputCall[1] as string)
-        
+
         // Should include all outputs (backward compatibility)
         expect(outputContent.networks[0].outputs).toEqual({
           'action1.result': 'result1',
@@ -434,11 +434,11 @@ describe('Deployer', () => {
             { name: 'verify2', template: 'template1', arguments: {}, output: false }
           ]
         }
-        
+
         mockLoader.jobs.clear()
         mockLoader.jobs.set('job-multiple-outputs', jobWithMultipleOutputs)
         mockGraph.getExecutionOrder.mockReturnValue(['job-multiple-outputs'])
-        
+
         // Mock context to return outputs from all actions
         mockContext.getOutputs.mockReturnValue(new Map<string, any>([
           ['deploy1.address', '0xdeploy1'],
@@ -453,7 +453,7 @@ describe('Deployer', () => {
         // Verify output file was written
         const outputCall = mockFs.writeFile.mock.calls[0]
         const outputContent = JSON.parse(outputCall[1] as string)
-        
+
         // Should include outputs from both deploy actions, but not verify actions
         expect(outputContent.networks[0].outputs).toEqual({
           'deploy1.address': '0xdeploy1',
@@ -467,7 +467,7 @@ describe('Deployer', () => {
         mockLoader.load.mockRejectedValue(new Error('Failed to load project'))
 
         const deployer = new Deployer(deployerOptions)
-        
+
         await expect(deployer.run()).rejects.toThrow('Failed to load project')
         // Note: Error handling is now done via events, not console.error directly
       })
@@ -478,25 +478,25 @@ describe('Deployer', () => {
         })
 
         const deployer = new Deployer(deployerOptions)
-        
+
         await expect(deployer.run()).rejects.toThrow('Circular dependency detected')
       })
 
             it('should capture job execution failures and then throw', async () => {
         mockEngine.executeJob.mockRejectedValue(new Error('Transaction failed'))
-        
+
         const deployer = new Deployer(deployerOptions)
-        
+
         await expect(deployer.run()).rejects.toThrow('One or more jobs failed during execution')
-        
+
         // Should still write output files with error entries before throwing
         expect(mockFs.writeFile).toHaveBeenCalled()
-        
+
         // Check that error entries are recorded
         const writeFileCalls = mockFs.writeFile.mock.calls
         const outputFile = writeFileCalls[0]
         const outputContent = JSON.parse(outputFile[1] as string)
-        
+
         // Should have error entries for failed executions
         const errorEntries = outputContent.networks.filter((entry: any) => entry.status === 'error')
         expect(errorEntries.length).toBeGreaterThan(0)
@@ -507,7 +507,7 @@ describe('Deployer', () => {
         mockFs.mkdir.mockRejectedValue(new Error('Permission denied'))
 
         const deployer = new Deployer(deployerOptions)
-        
+
         await expect(deployer.run()).rejects.toThrow('Permission denied')
       })
 
@@ -515,7 +515,7 @@ describe('Deployer', () => {
         mockFs.writeFile.mockRejectedValue(new Error('Disk full'))
 
         const deployer = new Deployer(deployerOptions)
-        
+
         await expect(deployer.run()).rejects.toThrow('Disk full')
       })
 
@@ -525,14 +525,14 @@ describe('Deployer', () => {
         })
 
         const deployer = new Deployer(deployerOptions)
-        
+
         await expect(deployer.run()).rejects.toThrow('One or more jobs failed during execution')
-        
+
         // Should record context creation failures as error entries before throwing
         const writeFileCalls = mockFs.writeFile.mock.calls
         const outputFile = writeFileCalls[0]
         const outputContent = JSON.parse(outputFile[1] as string)
-        
+
         const errorEntries = outputContent.networks.filter((entry: any) => entry.status === 'error')
         expect(errorEntries.length).toBeGreaterThan(0)
         expect(errorEntries[0].error).toBe('Invalid private key')
@@ -546,7 +546,7 @@ describe('Deployer', () => {
           name: 'weird-job',
           only_networks: [999] // Non-existent network
         }
-        
+
         mockLoader.jobs.clear()
         mockLoader.jobs.set('weird-job', weirdJob)
         mockGraph.getExecutionOrder.mockReturnValue(['weird-job'])
@@ -564,7 +564,7 @@ describe('Deployer', () => {
           name: 'weird-job',
           skip_networks: [1, 137] // Skip all available networks
         }
-        
+
         mockLoader.jobs.clear()
         mockLoader.jobs.set('weird-job', weirdJob)
         mockGraph.getExecutionOrder.mockReturnValue(['weird-job'])
@@ -578,12 +578,12 @@ describe('Deployer', () => {
 
       it('should handle runOnNetworks with non-existent chain IDs', async () => {
         const consoleSpy = jest.spyOn(console, 'warn').mockImplementation()
-        
+
         const options: DeployerOptions = {
           ...deployerOptions,
           runOnNetworks: [1, 999, 888] // 999 and 888 don't exist
         }
-        
+
         const deployer = new Deployer(options)
         await deployer.run()
 
@@ -599,9 +599,9 @@ describe('Deployer', () => {
           ...deployerOptions,
           runJobs: ['non-existent-job']
         }
-        
+
         const deployer = new Deployer(options)
-        
+
         await expect(deployer.run()).rejects.toThrow(
           'Specified job "non-existent-job" not found in project.'
         )
@@ -611,18 +611,18 @@ describe('Deployer', () => {
         const brokenContext = {
           // Missing getOutputs method
         } as any
-        
+
         MockExecutionContext.mockImplementation(() => brokenContext)
 
         const deployer = new Deployer(deployerOptions)
-        
+
         await expect(deployer.run()).rejects.toThrow('One or more jobs failed during execution')
-        
+
         // Should record the missing method error before throwing
         const writeFileCalls = mockFs.writeFile.mock.calls
         const outputFile = writeFileCalls[0]
         const outputContent = JSON.parse(outputFile[1] as string)
-        
+
         const errorEntries = outputContent.networks.filter((entry: any) => entry.status === 'error')
         expect(errorEntries.length).toBeGreaterThan(0)
       })
@@ -632,7 +632,7 @@ describe('Deployer', () => {
           ...deployerOptions,
           networks: []
         }
-        
+
         const deployer = new Deployer(options)
         await deployer.run()
 
@@ -646,7 +646,7 @@ describe('Deployer', () => {
           ...deployerOptions,
           runJobs: []
         }
-        
+
         const deployer = new Deployer(options)
         await deployer.run()
 
@@ -659,7 +659,7 @@ describe('Deployer', () => {
           ...deployerOptions,
           runOnNetworks: []
         }
-        
+
         const deployer = new Deployer(options)
         await deployer.run()
 
@@ -674,7 +674,7 @@ describe('Deployer', () => {
           only_networks: [1, 137],
           skip_networks: [137]
         }
-        
+
         mockLoader.jobs.clear()
         mockLoader.jobs.set('conflicted-job', conflictedJob)
         mockGraph.getExecutionOrder.mockReturnValue(['conflicted-job'])
@@ -696,20 +696,20 @@ describe('Deployer', () => {
         })
 
         const deployer = new Deployer(deployerOptions)
-        
+
         await expect(deployer.run()).rejects.toThrow('One or more jobs failed during execution')
-        
+
         // Should write output files with error entries before throwing
         expect(mockFs.writeFile).toHaveBeenCalled()
-        
+
         const writeFileCalls = mockFs.writeFile.mock.calls
         const outputFile = writeFileCalls[0]
         const outputContent = JSON.parse(outputFile[1] as string)
-        
+
         // All entries should be error entries
         const errorEntries = outputContent.networks.filter((entry: any) => entry.status === 'error')
         expect(errorEntries.length).toBeGreaterThan(0)
-        
+
         // No success entries
         const successEntries = outputContent.networks.filter((entry: any) => entry.status === 'success')
         expect(successEntries.length).toBe(0)
@@ -719,7 +719,7 @@ describe('Deployer', () => {
         // Create 100 jobs to test performance/memory
         const manyJobs = Array.from({ length: 100 }, (_, i) => `job${i}`)
         mockGraph.getExecutionOrder.mockReturnValue(manyJobs)
-        
+
         // Mock loader to have all these jobs
         for (let i = 0; i < 100; i++) {
           mockLoader.jobs.set(`job${i}`, {
@@ -756,14 +756,14 @@ describe('Deployer', () => {
             runJobs: ['job2']
           }
           const deployer = new Deployer(options)
-          
+
           // Initialize the deployer's graph by calling load
           await mockLoader.load()
           ;(deployer as any).graph = mockGraph
-          
+
           // Mock getDependencies to return job1 as dependency of job2
           mockGraph.getDependencies.mockReturnValueOnce(new Set(['job1']))
-          
+
           const fullOrder = ['job1', 'job2', 'job3']
           const plan = (deployer as any).getJobExecutionPlan(fullOrder)
           expect(plan).toEqual(['job1', 'job2'])
@@ -893,7 +893,7 @@ describe('Deployer', () => {
             runOnNetworks: [1]
           }
           const deployer = new Deployer(options)
-          
+
           const networks = (deployer as any).getTargetNetworks()
           expect(networks).toEqual([mockNetwork1])
         })
@@ -942,7 +942,7 @@ describe('Deployer', () => {
 
         mockLoader.jobs.set('job4', job4)
         mockGraph.getExecutionOrder.mockReturnValue(['job1', 'job2', 'job3', 'job4'])
-        
+
         // Mock dependencies
         mockGraph.getDependencies
           .mockReturnValueOnce(new Set()) // job1 has no deps
@@ -963,7 +963,7 @@ describe('Deployer', () => {
         const contextCalls = MockExecutionContext.mock.calls
         const mainnetCalls = contextCalls.filter(call => call[0].chainId === 1)
         const polygonCalls = contextCalls.filter(call => call[0].chainId === 137)
-        
+
         expect(mainnetCalls).toHaveLength(4) // All jobs run on mainnet
         expect(polygonCalls).toHaveLength(2) // Only job1 and job2 run on polygon
       })
@@ -975,7 +975,7 @@ describe('Deployer', () => {
           const currentCall = MockExecutionContext.mock.calls[callCount]
           const network = currentCall ? currentCall[0] : null
           callCount++
-          
+
           if (job.name === 'job2' && network && network.chainId === 137) {
             throw new Error('Polygon execution failed')
           }
@@ -983,19 +983,19 @@ describe('Deployer', () => {
         })
 
         const deployer = new Deployer(deployerOptions)
-        
+
         await expect(deployer.run()).rejects.toThrow('One or more jobs failed during execution')
-        
+
         // Should capture the partial failure in output files before throwing
         const writeFileCalls = mockFs.writeFile.mock.calls
-        const job2Output = writeFileCalls.find(call => 
+        const job2Output = writeFileCalls.find(call =>
           String(call[0]).includes('job2.json')
         )
-        
+
         if (job2Output) {
           const job2Content = JSON.parse(job2Output[1] as string)
           const errorEntries = job2Content.networks.filter((entry: any) => entry.status === 'error')
-          expect(errorEntries.some((entry: any) => 
+          expect(errorEntries.some((entry: any) =>
             entry.chainId === '137' && entry.error === 'Polygon execution failed'
           )).toBe(true)
         }
@@ -1019,22 +1019,22 @@ describe('Deployer', () => {
 
         // Verify outputs are correctly segregated by network since they have different outputs
         const writeFileCalls = mockFs.writeFile.mock.calls
-        const job1Output = writeFileCalls.find(call => 
+        const job1Output = writeFileCalls.find(call =>
           call[0] === '/test/project/output/job1.json'
         )
-        
+
         const job1Content = JSON.parse(job1Output![1] as string)
         // Since outputs differ by network, they should be in separate entries
         expect(job1Content.networks).toHaveLength(2)
-        
+
         // Find entries for each network
-        const network1Entry = job1Content.networks.find((entry: any) => 
+        const network1Entry = job1Content.networks.find((entry: any) =>
           entry.chainIds && entry.chainIds.includes('1')
         )
-        const network137Entry = job1Content.networks.find((entry: any) => 
+        const network137Entry = job1Content.networks.find((entry: any) =>
           entry.chainIds && entry.chainIds.includes('137')
         )
-        
+
         expect(network1Entry.outputs['action.hash']).toBe('0xhash-1')
         expect(network137Entry.outputs['action.hash']).toBe('0xhash-137')
       })
@@ -1056,10 +1056,10 @@ describe('Deployer', () => {
 
         // Verify identical outputs are grouped together
         const writeFileCalls = mockFs.writeFile.mock.calls
-        const job1Output = writeFileCalls.find(call => 
+        const job1Output = writeFileCalls.find(call =>
           call[0] === '/test/project/output/job1.json'
         )
-        
+
         const job1Content = JSON.parse(job1Output![1] as string)
         // Since outputs are identical, they should be grouped into one entry
         expect(job1Content.networks).toHaveLength(1)
@@ -1075,7 +1075,7 @@ describe('Deployer', () => {
           const currentCall = MockExecutionContext.mock.calls[callCount]
           const network = currentCall ? currentCall[0] : null
           callCount++
-          
+
           if (job.name === 'job1' && network && network.chainId === 137) {
             throw new Error('Polygon execution failed')
           }
@@ -1098,21 +1098,21 @@ describe('Deployer', () => {
 
         // Verify outputs show both success and error states before throwing
         const writeFileCalls = mockFs.writeFile.mock.calls
-        const job1Output = writeFileCalls.find(call => 
+        const job1Output = writeFileCalls.find(call =>
           call[0] === '/test/project/output/job1.json'
         )
-        
+
         const job1Content = JSON.parse(job1Output![1] as string)
         expect(job1Content.networks).toHaveLength(2) // One success entry, one error entry
-        
+
         // Find success and error entries
         const successEntry = job1Content.networks.find((entry: any) => entry.status === 'success')
         const errorEntry = job1Content.networks.find((entry: any) => entry.status === 'error')
-        
+
         expect(successEntry).toBeDefined()
         expect(successEntry.chainIds).toEqual(['1'])
         expect(successEntry.outputs['contract.address']).toBe('0x1234567890123456789012345678901234567890')
-        
+
         expect(errorEntry).toBeDefined()
         expect(errorEntry.chainId).toBe('137')
         expect(errorEntry.error).toBe('Polygon execution failed')
@@ -1137,9 +1137,9 @@ describe('Deployer', () => {
       mockEngine.executeJob.mockRejectedValueOnce(new Error('First job failed'))
 
       const deployer = new Deployer(options)
-      
+
       await expect(deployer.run()).rejects.toThrow('First job failed')
-      
+
       // Should only attempt the first execution, not continue to other networks/jobs
       expect(mockEngine.executeJob).toHaveBeenCalledTimes(1)
     })
@@ -1156,9 +1156,9 @@ describe('Deployer', () => {
       mockEngine.executeJob.mockResolvedValue(undefined)
 
       const deployer = new Deployer(options)
-      
+
       await expect(deployer.run()).rejects.toThrow('One or more jobs failed during execution')
-      
+
       // Should attempt all executions (2 networks * 1 job = 2 calls)
       expect(mockEngine.executeJob).toHaveBeenCalledTimes(2)
     })
@@ -1175,9 +1175,9 @@ describe('Deployer', () => {
       mockEngine.executeJob.mockResolvedValue(undefined)
 
       const deployer = new Deployer(options)
-      
+
       await expect(deployer.run()).rejects.toThrow('One or more jobs failed during execution')
-      
+
       // Should attempt all executions
       expect(mockEngine.executeJob).toHaveBeenCalledTimes(2)
     })
@@ -1193,9 +1193,9 @@ describe('Deployer', () => {
       mockEngine.executeJob.mockResolvedValue(undefined)
 
       const deployer = new Deployer(options)
-      
+
       await expect(deployer.run()).resolves.not.toThrow()
-      
+
       // Should complete all executions
       expect(mockEngine.executeJob).toHaveBeenCalledTimes(2)
     })
@@ -1241,7 +1241,7 @@ describe('Deployer', () => {
       }
 
       const deployer = new Deployer(optionsWithIgnoreVerifyErrors)
-      
+
       // Mock event emitter to track events
       const mockEmitEvent = jest.fn()
       ;(deployer as any).events = { emitEvent: mockEmitEvent }
@@ -1266,7 +1266,7 @@ describe('Deployer', () => {
       }
 
       const deployer = new Deployer(optionsWithoutIgnoreVerifyErrors)
-      
+
       // Mock event emitter to track events
       const mockEmitEvent = jest.fn()
       ;(deployer as any).events = { emitEvent: mockEmitEvent }
@@ -1291,7 +1291,7 @@ describe('Deployer', () => {
       }
 
       const deployer = new Deployer(optionsWithIgnoreVerifyErrors)
-      
+
       // Mock event emitter to track events
       const mockEmitEvent = jest.fn()
       ;(deployer as any).events = { emitEvent: mockEmitEvent }
@@ -1306,4 +1306,346 @@ describe('Deployer', () => {
       )
     })
   })
-}) 
+
+  describe('job dependency failure handling', () => {
+    // Test constants
+    const TEST_BYTECODES = {
+      SIMPLE_CONTRACT: '0x6080604052348015600e575f5ffd5b5060c180601a5f395ff3fe6080604052348015600e575f5ffd5b50600436106030575f3560e01c806390c52443146034578063d09de08a14604d575b5f5ffd5b603b5f5481565b60405190815260200160405180910390f35b60536055565b005b5f805490806061836068565b9190505550565b5f60018201608457634e487b7160e01b5f52601160045260245ffd5b506001019056fea264697066735822122061c8cc43c72d6b23b16f7a7337dd15b93d71eb94a9d5247911e39f486e1f94f964736f6c634300081e0033',
+      BROKEN_BYTECODE: '0xff'
+    } as const
+
+    it('should fail job B when job A fails due to dependency failure', async () => {
+      // Create jobs with dependency
+      const jobA: Job = {
+        name: 'job-a',
+        version: '1',
+        description: 'Deploy a contract with broken bytecode (will fail)',
+        actions: [
+          {
+            name: 'failing-deploy',
+            type: 'create-contract',
+            arguments: {
+              bytecode: TEST_BYTECODES.BROKEN_BYTECODE,
+              value: '0'
+            },
+            output: true
+          }
+        ]
+      }
+
+      const jobB: Job = {
+        name: 'job-b',
+        version: '1',
+        description: 'Use output from failed job A',
+        depends_on: ['job-a'],
+        actions: [
+          {
+            name: 'use-failed-output',
+            type: 'send-transaction',
+            arguments: {
+              to: '{{job-a.failing-deploy.address}}',
+              data: '0x',
+              value: '0'
+            }
+          }
+        ]
+      }
+
+      // Setup mocks
+      const mockJobs = new Map<string, Job>()
+      mockJobs.set('job-a', jobA)
+      mockJobs.set('job-b', jobB)
+
+      const mockTemplates = new Map<string, Template>()
+
+      MockProjectLoader.mockImplementation(() => ({
+        load: jest.fn().mockResolvedValue(undefined),
+        jobs: mockJobs,
+        templates: mockTemplates
+      } as any))
+
+      MockDependencyGraph.mockImplementation(() => ({
+        getExecutionOrder: jest.fn().mockReturnValue(['job-a', 'job-b']),
+        getDependencies: jest.fn().mockReturnValue(new Set())
+      } as any))
+
+      // Mock engine to simulate job A failure
+      MockExecutionEngine.mockImplementation(() => ({
+        executeJob: jest.fn().mockImplementation(async (job: Job) => {
+          if (job.name === 'job-a') {
+            throw new Error('Contract deployment failed: invalid bytecode')
+          }
+          // job-b should not be executed due to dependency failure
+        })
+      } as any))
+
+      MockExecutionContext.mockImplementation(() => ({
+        dispose: jest.fn().mockResolvedValue(undefined),
+        getNetwork: jest.fn().mockReturnValue(mockNetwork1)
+      } as any))
+
+      const deployer = new Deployer(deployerOptions)
+
+      // Execute deployer - should fail due to job A failure
+      await expect(deployer.run()).rejects.toThrow('One or more jobs failed during execution')
+
+      // Verify that job A failed
+      const results = (deployer as any).results
+      const jobAResult = results.get('job-a')
+      expect(jobAResult).toBeDefined()
+      expect(jobAResult.outputs.get(mockNetwork1.chainId).status).toBe('error')
+
+      // Verify that job B failed due to dependency failure
+      const jobBResult = results.get('job-b')
+      expect(jobBResult).toBeDefined()
+      const jobBError = jobBResult.outputs.get(mockNetwork1.chainId)
+      expect(jobBError.status).toBe('error')
+      expect(jobBError.data).toContain('depends on "job-a", but "job-a" failed')
+    })
+
+    it('should fail job B when referencing non-existent job outputs', async () => {
+      // Create job B that references non-existent job
+      const jobB: Job = {
+        name: 'job-b',
+        version: '1',
+        description: 'Reference non-existent job outputs',
+        actions: [
+          {
+            name: 'use-output-step',
+            type: 'send-transaction',
+            arguments: {
+              to: '{{non-existent-job.deploy-step.address}}',
+              data: '0x',
+              value: '0'
+            }
+          }
+        ]
+      }
+
+      // Setup mocks
+      const mockJobs = new Map<string, Job>()
+      mockJobs.set('job-b', jobB)
+
+      const mockTemplates = new Map<string, Template>()
+
+      MockProjectLoader.mockImplementation(() => ({
+        load: jest.fn().mockResolvedValue(undefined),
+        jobs: mockJobs,
+        templates: mockTemplates
+      } as any))
+
+      MockDependencyGraph.mockImplementation(() => ({
+        getExecutionOrder: jest.fn().mockReturnValue(['job-b']),
+        getDependencies: jest.fn().mockReturnValue(new Set())
+      } as any))
+
+      // Mock engine to simulate expression resolution failure
+      MockExecutionEngine.mockImplementation(() => ({
+        executeJob: jest.fn().mockRejectedValue(new Error('Output for key "non-existent-job.deploy-step.address" not found in context'))
+      } as any))
+
+      MockExecutionContext.mockImplementation(() => ({
+        dispose: jest.fn().mockResolvedValue(undefined),
+        getNetwork: jest.fn().mockReturnValue(mockNetwork1)
+      } as any))
+
+      const deployer = new Deployer(deployerOptions)
+
+      // Execute deployer - should fail due to expression resolution
+      await expect(deployer.run()).rejects.toThrow('One or more jobs failed during execution')
+
+      // Verify that job B failed
+      const results = (deployer as any).results
+      const jobBResult = results.get('job-b')
+      expect(jobBResult).toBeDefined()
+      expect(jobBResult.outputs.get(mockNetwork1.chainId).status).toBe('error')
+    })
+
+    it('should handle job B with no dependency on job A but references job A outputs', async () => {
+      // This tests the edge case where a job references outputs from another job
+      // without explicitly declaring a dependency. This should work if job A succeeds.
+
+      const jobA: Job = {
+        name: 'job-a',
+        version: '1',
+        description: 'Deploy a contract successfully',
+        actions: [
+          {
+            name: 'deploy-step',
+            type: 'create-contract',
+            arguments: {
+              bytecode: TEST_BYTECODES.SIMPLE_CONTRACT,
+              value: '0'
+            },
+            output: true
+          }
+        ]
+      }
+
+      const jobB: Job = {
+        name: 'job-b',
+        version: '1',
+        description: 'Reference job A outputs without explicit dependency',
+        // No depends_on field - this is the key difference
+        actions: [
+          {
+            name: 'use-output-step',
+            type: 'send-transaction',
+            arguments: {
+              to: '{{job-a.deploy-step.address}}',
+              data: '0x',
+              value: '0'
+            }
+          }
+        ]
+      }
+
+      // Setup mocks
+      const mockJobs = new Map<string, Job>()
+      mockJobs.set('job-a', jobA)
+      mockJobs.set('job-b', jobB)
+
+      const mockTemplates = new Map<string, Template>()
+
+      MockProjectLoader.mockImplementation(() => ({
+        load: jest.fn().mockResolvedValue(undefined),
+        jobs: mockJobs,
+        templates: mockTemplates
+      } as any))
+
+      MockDependencyGraph.mockImplementation(() => ({
+        getExecutionOrder: jest.fn().mockReturnValue(['job-a', 'job-b']),
+        getDependencies: jest.fn().mockReturnValue(new Set())
+      } as any))
+
+      // Mock engine to simulate successful execution
+      MockExecutionEngine.mockImplementation(() => ({
+        executeJob: jest.fn().mockImplementation(async (job: Job) => {
+          if (job.name === 'job-a') {
+            // Simulate successful job A execution
+            return Promise.resolve()
+          } else if (job.name === 'job-b') {
+            // Simulate successful job B execution (no dependency check needed)
+            return Promise.resolve()
+          }
+        })
+      } as any))
+
+      MockExecutionContext.mockImplementation(() => ({
+        dispose: jest.fn().mockResolvedValue(undefined),
+        getNetwork: jest.fn().mockReturnValue(mockNetwork1),
+        getOutputs: jest.fn().mockReturnValue(new Map([
+          ['deploy-step.address', '0x5FbDB2315678afecb367f032d93F642f64180aa3'],
+          ['deploy-step.hash', '0xmockdeployhash123']
+        ]))
+      } as any))
+
+      const deployer = new Deployer(deployerOptions)
+
+      // Execute deployer - should succeed since job A succeeds and job B has no explicit dependency
+      await expect(deployer.run()).resolves.not.toThrow()
+
+      // Verify both jobs succeeded
+      const results = (deployer as any).results
+      const jobAResult = results.get('job-a')
+      const jobBResult = results.get('job-b')
+
+      expect(jobAResult).toBeDefined()
+      expect(jobAResult.outputs.get(mockNetwork1.chainId).status).toBe('success')
+
+      expect(jobBResult).toBeDefined()
+      expect(jobBResult.outputs.get(mockNetwork1.chainId).status).toBe('success')
+    })
+
+    it('should fail job B when job A fails, even with complex output references', async () => {
+      // This tests the scenario where job B references multiple outputs from job A
+      // and job A fails, ensuring job B fails due to dependency failure, not expression resolution
+
+      const jobA: Job = {
+        name: 'job-a',
+        version: '1',
+        description: 'Deploy a contract with broken bytecode (will fail)',
+        actions: [
+          {
+            name: 'failing-deploy',
+            type: 'create-contract',
+            arguments: {
+              bytecode: TEST_BYTECODES.BROKEN_BYTECODE,
+              value: '0'
+            },
+            output: true
+          }
+        ]
+      }
+
+      const jobB: Job = {
+        name: 'job-b',
+        version: '1',
+        description: 'Use multiple outputs from failed job A',
+        depends_on: ['job-a'],
+        actions: [
+          {
+            name: 'use-multiple-outputs',
+            type: 'send-transaction',
+            arguments: {
+              to: '{{job-a.failing-deploy.address}}',
+              data: '0x',
+              value: '0'
+            }
+          }
+        ]
+      }
+
+      // Setup mocks
+      const mockJobs = new Map<string, Job>()
+      mockJobs.set('job-a', jobA)
+      mockJobs.set('job-b', jobB)
+
+      const mockTemplates = new Map<string, Template>()
+
+      MockProjectLoader.mockImplementation(() => ({
+        load: jest.fn().mockResolvedValue(undefined),
+        jobs: mockJobs,
+        templates: mockTemplates
+      } as any))
+
+      MockDependencyGraph.mockImplementation(() => ({
+        getExecutionOrder: jest.fn().mockReturnValue(['job-a', 'job-b']),
+        getDependencies: jest.fn().mockReturnValue(new Set())
+      } as any))
+
+      // Mock engine to simulate job A failure
+      MockExecutionEngine.mockImplementation(() => ({
+        executeJob: jest.fn().mockImplementation(async (job: Job) => {
+          if (job.name === 'job-a') {
+            throw new Error('Contract deployment failed: invalid bytecode')
+          }
+          // job-b should not be executed due to dependency failure
+        })
+      } as any))
+
+      MockExecutionContext.mockImplementation(() => ({
+        dispose: jest.fn().mockResolvedValue(undefined),
+        getNetwork: jest.fn().mockReturnValue(mockNetwork1)
+      } as any))
+
+      const deployer = new Deployer(deployerOptions)
+
+      // Execute deployer - should fail due to job A failure
+      await expect(deployer.run()).rejects.toThrow('One or more jobs failed during execution')
+
+      // Verify that job A failed
+      const results = (deployer as any).results
+      const jobAResult = results.get('job-a')
+      expect(jobAResult).toBeDefined()
+      expect(jobAResult.outputs.get(mockNetwork1.chainId).status).toBe('error')
+
+      // Verify that job B failed due to dependency failure
+      const jobBResult = results.get('job-b')
+      expect(jobBResult).toBeDefined()
+      const jobBError = jobBResult.outputs.get(mockNetwork1.chainId)
+      expect(jobBError.status).toBe('error')
+      expect(jobBError.data).toContain('depends on "job-a", but "job-a" failed')
+    })
+  })
+})


### PR DESCRIPTION
Previously, a failed dependency would not prevent a job from running. 