### PR TITLE
Add signing actions

### DIFF
--- a/src/lib/__tests__/network-loader.spec.ts
+++ b/src/lib/__tests__/network-loader.spec.ts
@@ -97,6 +97,7 @@ describe('network-loader rpcUrl token replacement', () => {
     const networks = await loadNetworks(projectRoot)
     expect(networks[0].rpcUrl).toBe('https://node.example.com/')
   })
+
 })
 
 describe('network-loader params', () => {

--- a/src/lib/core/__tests__/resolver.spec.ts
+++ b/src/lib/core/__tests__/resolver.spec.ts
@@ -22,6 +22,16 @@ describe('ValueResolver', () => {
       supports: ["sourcify", "etherscan_v2"],
       gasLimit: 10000000,
       evmVersion: 'cancun',
+      params: {
+        dataSource: {
+          endpoint: 'https://api.example.com/data',
+          domain: {
+            name: 'Example',
+            version: '1',
+          },
+        },
+        blockMode: 'small',
+      },
     }
     // A dummy private key is fine as these tests don't send transactions
     const mockPrivateKey = '0x0000000000000000000000000000000000000000000000000000000000000001'
@@ -1571,6 +1581,16 @@ describe('ValueResolver', () => {
         const result = await resolver.resolve('{{Network().evmVersion}}', context)
         expect(result).toBe(mockNetwork.evmVersion)
       })
+
+      it('should return params metadata object for valid network', async () => {
+        const result = await resolver.resolve('{{Network().params}}', context)
+        expect(result).toEqual(mockNetwork.params)
+      })
+
+      it('should resolve nested params metadata path', async () => {
+        const result = await resolver.resolve('{{Network().params.dataSource.endpoint}}', context)
+        expect(result).toBe('https://api.example.com/data')
+      })
     })
 
     describe('Network().params dotted paths', () => {
@@ -1624,6 +1644,11 @@ describe('ValueResolver', () => {
       it('should fail for undefined property', async () => {
         await expect(resolver.resolve('{{Network().undefined}}', context))
           .rejects.toThrow('Property "undefined" does not exist on network')
+      })
+
+      it('should default missing nested property to false', async () => {
+        const result = await resolver.resolve('{{Network().params.missing}}', context)
+        expect(result).toBe(false)
       })
 
       it('should fail for network with reference', async () => {

--- a/src/lib/core/__tests__/sign-actions.spec.ts
+++ b/src/lib/core/__tests__/sign-actions.spec.ts
@@ -1,0 +1,148 @@
+import { ExecutionEngine } from '../engine'
+import { ExecutionContext } from '../context'
+import { ContractRepository } from '../../contracts/repository'
+import { Job, Network } from '../../types'
+import { ethers } from 'ethers'
+
+const TEST_WALLET = ethers.Wallet.createRandom()
+const PRIVATE_KEY = TEST_WALLET.privateKey
+
+const networkConfig: Network = {
+  name: 'Testnet',
+  chainId: 1337,
+  rpcUrl: 'http://127.0.0.1:8545'
+}
+
+describe('sign primitives', () => {
+  let engine: ExecutionEngine
+  let context: ExecutionContext
+
+  beforeEach(async () => {
+    engine = new ExecutionEngine(new Map())
+    context = new ExecutionContext(networkConfig, PRIVATE_KEY, new ContractRepository())
+  })
+
+  afterEach(async () => {
+    await context.dispose()
+  })
+
+  it('signs a raw digest', async () => {
+    const digest = ethers.keccak256(ethers.toUtf8Bytes('catapult-sign-digest'))
+
+    const job: Job = {
+      name: 'sign-digest',
+      version: '1',
+      actions: [
+        {
+          name: 'digest',
+          type: 'sign-digest',
+          arguments: {
+            digest
+          }
+        }
+      ]
+    }
+
+    await engine.executeJob(job, context)
+
+    const expectedSignature = ethers.Signature.from(TEST_WALLET.signingKey.sign(ethers.getBytes(digest))).serialized
+
+    expect(context.getOutput('digest.signature')).toBe(expectedSignature)
+    expect(context.getOutput('digest.digest')).toBe(ethers.hexlify(digest))
+  })
+
+  it('signs typed data payloads', async () => {
+    const domain = {
+      name: 'Test Mail',
+      version: '1',
+      chainId: 1337,
+      verifyingContract: '0x0000000000000000000000000000000000000001'
+    }
+
+    const types = {
+      EIP712Domain: [
+        { name: 'name', type: 'string' },
+        { name: 'version', type: 'string' },
+        { name: 'chainId', type: 'uint256' },
+        { name: 'verifyingContract', type: 'address' }
+      ],
+      Mail: [
+        { name: 'from', type: 'Person' },
+        { name: 'to', type: 'Person' },
+        { name: 'contents', type: 'string' }
+      ],
+      Person: [
+        { name: 'name', type: 'string' },
+        { name: 'wallet', type: 'address' }
+      ]
+    }
+
+    const message = {
+      from: {
+        name: 'Alice',
+        wallet: TEST_WALLET.address
+      },
+      to: {
+        name: 'Bob',
+        wallet: '0x0000000000000000000000000000000000000002'
+      },
+      contents: 'Hello from Catapult!'
+    }
+
+    const job: Job = {
+      name: 'sign-typed-data',
+      version: '1',
+      actions: [
+        {
+          name: 'typed',
+          type: 'sign-typed-data',
+          arguments: {
+            domain,
+            types,
+            message,
+            primaryType: 'Mail'
+          }
+        }
+      ]
+    }
+
+    await engine.executeJob(job, context)
+
+    const normalizedTypes = {
+      Mail: types.Mail,
+      Person: types.Person
+    }
+    const expectedSignature = await TEST_WALLET.signTypedData(domain, normalizedTypes, message)
+
+    expect(context.getOutput('typed.signature')).toBe(expectedSignature)
+    expect(context.getOutput('typed.domain')).toEqual(domain)
+    expect(context.getOutput('typed.types')).toEqual(types)
+    expect(context.getOutput('typed.message')).toEqual(message)
+    expect(context.getOutput('typed.primaryType')).toBe('Mail')
+  })
+
+  it('signs arbitrary messages via EIP-191', async () => {
+    const message = 'Hello from Catapult!'
+
+    const job: Job = {
+      name: 'sign-message',
+      version: '1',
+      actions: [
+        {
+          name: 'msg',
+          type: 'sign-message',
+          arguments: {
+            message
+          }
+        }
+      ]
+    }
+
+    await engine.executeJob(job, context)
+
+    const expectedSignature = await TEST_WALLET.signMessage(message)
+    expect(context.getOutput('msg.signature')).toBe(expectedSignature)
+    expect(context.getOutput('msg.message')).toBe(message)
+  })
+})
+

--- a/src/lib/core/__tests__/signer.spec.ts
+++ b/src/lib/core/__tests__/signer.spec.ts
@@ -1,0 +1,50 @@
+import { ethers } from 'ethers'
+import { toDigestSigner } from '../signer'
+
+describe('toDigestSigner', () => {
+  it('returns the same signer if it already supports signDigest', async () => {
+    const wallet = ethers.Wallet.createRandom()
+    const digestSigner = wallet as typeof wallet & { signDigest: jest.Mock }
+    digestSigner.signDigest = jest.fn().mockResolvedValue('0xdeadbeef')
+
+    const digest = ethers.keccak256(ethers.toUtf8Bytes('existing-digest-signer'))
+    const result = toDigestSigner(digestSigner)
+    const signature = await result.signDigest(digest)
+
+    expect(result).toBe(digestSigner)
+    expect(signature).toBe('0xdeadbeef')
+    expect(digestSigner.signDigest).toHaveBeenCalledWith(digest)
+  })
+
+  it('adds signDigest support for wallets using the raw digest', async () => {
+    const wallet = ethers.Wallet.createRandom()
+    const digest = ethers.keccak256(ethers.toUtf8Bytes('wallet-digest'))
+
+    const digestSigner = toDigestSigner(wallet)
+    const signature = await digestSigner.signDigest(digest)
+
+    const expectedSignature = ethers.Signature.from(
+      wallet.signingKey.sign(ethers.getBytes(digest))
+    ).serialized
+    expect(signature).toBe(expectedSignature)
+  })
+
+  it('wraps JsonRpcSigner by delegating to legacy sign message', async () => {
+    const provider = new ethers.JsonRpcProvider('http://127.0.0.1:8545')
+    const signer = await provider.getSigner()
+    const legacySign = jest.fn(async () => '0xlegacy')
+    ;(signer as any)._legacySignMessage = legacySign
+
+    const digest = ethers.keccak256(ethers.toUtf8Bytes('jsonrpc-digest'))
+    const digestSigner = toDigestSigner(signer)
+    const signature = await digestSigner.signDigest(digest)
+
+    expect(signature).toBe('0xlegacy')
+    expect(legacySign).toHaveBeenCalledWith(ethers.getBytes(digest))
+
+    if ((provider as any).destroy) {
+      await provider.destroy()
+    }
+  })
+})
+

--- a/src/lib/core/context.ts
+++ b/src/lib/core/context.ts
@@ -1,16 +1,17 @@
 import { ethers } from 'ethers'
 import { Network } from '../types'
 import { ContractRepository } from '../contracts/repository'
+import { DigestSigner, toDigestSigner } from './signer'
 
 export class ExecutionContext {
  public readonly provider: ethers.JsonRpcProvider
- public readonly signer: ethers.Signer | Promise<ethers.Signer> // Allow Promise for implicit signer
+ public readonly signer: DigestSigner | Promise<DigestSigner> // Allow Promise for implicit signer
  public readonly contractRepository: ContractRepository
  private outputs: Map<string, any> = new Map()
  private network: Network
  private etherscanApiKey?: string
  private currentContextPath?: string
- private resolvedSigner?: ethers.Signer // Cache for resolved signer
+ private resolvedSigner?: DigestSigner // Cache for resolved signer
 
   // Constants registries
   private topLevelConstants: Map<string, any> = new Map()
@@ -33,11 +34,13 @@ export class ExecutionContext {
 
    // Determine the signer
    if (privateKey) {
-     this.signer = new ethers.NonceManager(new ethers.Wallet(privateKey, this.provider))
+     // Wrap in NonceManager for nonce management, then in a DigestSigner so
+     // sign-digest/message/typed-data actions can reach the underlying key.
+     this.signer = toDigestSigner(new ethers.NonceManager(new ethers.Wallet(privateKey, this.provider)))
    } else if (network.rpcUrl) {
      // If no private key, but RPC URL is provided, get a signer from the provider.
      // This returns a Promise that we need to resolve on first use.
-     this.signer = this.provider.getSigner().then(signer => new ethers.NonceManager(signer)) // Keep as Promise
+     this.signer = this.provider.getSigner().then(signer => toDigestSigner(new ethers.NonceManager(signer))) // Keep as Promise
    } else {
      throw new Error('A private key must be provided or an RPC URL must be configured to obtain a signer for the network.')
    }
@@ -46,7 +49,7 @@ export class ExecutionContext {
  /**
   * Get the resolved signer, handling both direct signers and promised signers
   */
- public async getResolvedSigner(): Promise<ethers.Signer> {
+ public async getResolvedSigner(): Promise<DigestSigner> {
    if (this.resolvedSigner) {
      return this.resolvedSigner
    }

--- a/src/lib/core/engine.ts
+++ b/src/lib/core/engine.ts
@@ -1,4 +1,14 @@
-import { Job, Template, Action, JobAction, isPrimitiveActionType, Condition } from '../types'
+import {
+  Job,
+  Template,
+  Action,
+  JobAction,
+  isPrimitiveActionType,
+  Condition,
+  SignDigestAction,
+  SignMessageAction,
+  SignTypedDataAction
+} from '../types'
 import { Contract } from '../types/contracts'
 import { ExecutionContext } from './context'
 import { ValueResolver, ResolutionScope } from './resolver'
@@ -7,6 +17,7 @@ import { DeploymentEventEmitter, deploymentEvents } from '../events'
 import { createDefaultVerificationRegistry, VerificationPlatformRegistry } from '../verification/etherscan'
 import { BuildInfo } from '../types/buildinfo'
 import { ethers } from 'ethers'
+import type { TypedDataField } from 'ethers'
 
 export type EngineOptions = {
   eventEmitter?: DeploymentEventEmitter
@@ -1039,9 +1050,222 @@ export class ExecutionEngine {
         }
         break
       }
+      case 'sign-digest': {
+        const signAction = action as SignDigestAction
+        if (!signAction.arguments?.digest) {
+          throw new Error(`Action "${actionName}": "digest" argument is required for sign-digest.`)
+        }
+
+        let resolvedDigest: any
+        try {
+          resolvedDigest = await this.resolver.resolve(signAction.arguments.digest, context, scope)
+        } catch (error) {
+          if (error instanceof Error && /Unknown value resolver type/.test(error.message)) {
+            resolvedDigest = await this.resolveLiteralObject(signAction.arguments.digest, context, scope)
+          } else {
+            throw error
+          }
+        }
+        let normalizedDigest: string
+        if (typeof resolvedDigest === 'string') {
+          if (!ethers.isHexString(resolvedDigest)) {
+            throw new Error(`Action "${actionName}": digest must be a hex string.`)
+          }
+        }
+        try {
+          normalizedDigest = ethers.hexlify(resolvedDigest)
+        } catch {
+          throw new Error(`Action "${actionName}": digest must resolve to bytes or hex string.`)
+        }
+
+        if (!ethers.isHexString(normalizedDigest, 32)) {
+          throw new Error(`Action "${actionName}": digest must be 32 bytes (got ${ethers.getBytes(normalizedDigest).length}).`)
+        }
+
+        const signer = await context.getResolvedSigner()
+        const signature = await signer.signDigest(normalizedDigest)
+
+        if (action.name && !hasCustomOutput) {
+          context.setOutput(`${action.name}.signature`, signature)
+          context.setOutput(`${action.name}.digest`, normalizedDigest)
+        }
+        break
+      }
+      case 'sign-message': {
+        const signAction = action as SignMessageAction
+        if (!signAction.arguments?.message) {
+          throw new Error(`Action "${actionName}": "message" argument is required for sign-message.`)
+        }
+
+        let resolvedMessage: any
+        try {
+          resolvedMessage = await this.resolver.resolve(signAction.arguments.message, context, scope)
+        } catch (error) {
+          if (error instanceof Error && /Unknown value resolver type/.test(error.message)) {
+            resolvedMessage = await this.resolveLiteralObject(signAction.arguments.message, context, scope)
+          } else {
+            throw error
+          }
+        }
+
+        const { payload, storedRepresentation } = this.normalizeSignMessagePayload(resolvedMessage, actionName)
+        const signer = await context.getResolvedSigner()
+        const signature = await signer.signMessage(payload)
+
+        if (action.name && !hasCustomOutput) {
+          context.setOutput(`${action.name}.signature`, signature)
+          context.setOutput(`${action.name}.message`, storedRepresentation)
+        }
+        break
+      }
+      case 'sign-typed-data': {
+        const signAction = action as SignTypedDataAction
+        const args = signAction.arguments
+        if (!args?.domain || !args.types || !args.message) {
+          throw new Error(`Action "${actionName}": domain, types, and message arguments are required for sign-typed-data.`)
+        }
+
+        const resolvedDomain = await this.resolveLiteralObject(args.domain, context, scope)
+        if (!resolvedDomain || typeof resolvedDomain !== 'object' || Array.isArray(resolvedDomain)) {
+          throw new Error(`Action "${actionName}": domain must resolve to an object.`)
+        }
+
+        const resolvedTypes = await this.resolveLiteralObject(args.types, context, scope)
+        if (!resolvedTypes || typeof resolvedTypes !== 'object' || Array.isArray(resolvedTypes)) {
+          throw new Error(`Action "${actionName}": types must resolve to an object map.`)
+        }
+        for (const [typeName, fields] of Object.entries(resolvedTypes as Record<string, any>)) {
+          if (!Array.isArray(fields)) {
+            throw new Error(`Action "${actionName}": type definition "${typeName}" must be an array of fields.`)
+          }
+          for (const field of fields) {
+            if (!field || typeof field !== 'object' || typeof field.name !== 'string' || typeof field.type !== 'string') {
+              throw new Error(`Action "${actionName}": type definition "${typeName}" contains invalid field entries.`)
+            }
+          }
+        }
+
+        const resolvedMessage = await this.resolveLiteralObject(args.message, context, scope)
+        if (!resolvedMessage || typeof resolvedMessage !== 'object' || Array.isArray(resolvedMessage)) {
+          throw new Error(`Action "${actionName}": message must resolve to an object.`)
+        }
+
+        const primaryTypeOverride = args.primaryType ? await this.resolver.resolve(args.primaryType, context, scope) : undefined
+        if (primaryTypeOverride !== undefined && typeof primaryTypeOverride !== 'string') {
+          throw new Error(`Action "${actionName}": primaryType must resolve to a string when provided.`)
+        }
+
+        const resolvedPrimaryType =
+          primaryTypeOverride ??
+          this.inferPrimaryType(resolvedTypes as Record<string, TypedDataField[]>, actionName)
+
+        const normalizedTypes = this.normalizeTypedDataTypes(
+          resolvedTypes as Record<string, TypedDataField[]>,
+          resolvedPrimaryType
+        )
+
+        const signer = await context.getResolvedSigner()
+        const signature = await signer.signTypedData(
+          resolvedDomain as Record<string, any>,
+          normalizedTypes,
+          resolvedMessage as Record<string, any>
+        )
+
+        if (action.name && !hasCustomOutput) {
+          context.setOutput(`${action.name}.signature`, signature)
+          context.setOutput(`${action.name}.domain`, resolvedDomain)
+          context.setOutput(`${action.name}.types`, resolvedTypes)
+          context.setOutput(`${action.name}.message`, resolvedMessage)
+          context.setOutput(`${action.name}.primaryType`, resolvedPrimaryType)
+        }
+        break
+      }
       default:
         throw new Error(`Unknown or unimplemented primitive action type: ${(action as any).type}`)
     }
+  }
+
+  private inferPrimaryType(types: Record<string, TypedDataField[]>, actionName: string): string {
+    const candidates = Object.keys(types).filter(name => name !== 'EIP712Domain')
+    if (candidates.length === 1) {
+      return candidates[0]
+    }
+    if (candidates.length === 0) {
+      throw new Error(`Action "${actionName}": primaryType could not be inferred; please provide arguments.primaryType.`)
+    }
+    throw new Error(
+      `Action "${actionName}": primaryType is ambiguous (${candidates.join(
+        ', '
+      )}); please provide arguments.primaryType.`
+    )
+  }
+
+  private normalizeTypedDataTypes(
+    types: Record<string, TypedDataField[]>,
+    primaryType: string
+  ): Record<string, TypedDataField[]> {
+    const normalized: Record<string, TypedDataField[]> = {}
+    if (!types[primaryType]) {
+      throw new Error(`Primary type "${primaryType}" is not defined in supplied types.`)
+    }
+    normalized[primaryType] = types[primaryType]
+    for (const [key, value] of Object.entries(types)) {
+      if (key === primaryType || key === 'EIP712Domain') continue
+      normalized[key] = value
+    }
+    return normalized
+  }
+
+  private normalizeSignMessagePayload(
+    message: any,
+    actionName: string
+  ): { payload: string | Uint8Array; storedRepresentation: string } {
+    if (typeof message === 'string') {
+      return { payload: message, storedRepresentation: message }
+    }
+    try {
+      const bytes = ethers.getBytes(message)
+      return { payload: bytes, storedRepresentation: ethers.hexlify(bytes) }
+    } catch {
+      throw new Error(`Action "${actionName}": message must resolve to a string or bytes-like value.`)
+    }
+  }
+
+  private async resolveLiteralObject(
+    value: any,
+    context: ExecutionContext,
+    scope: ResolutionScope
+  ): Promise<any> {
+    if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean' || value === null) {
+      return this.resolver.resolve(value as any, context, scope)
+    }
+
+    if (Array.isArray(value)) {
+      return Promise.all(value.map(item => this.resolveLiteralObject(item, context, scope)))
+    }
+
+    if (value && typeof value === 'object') {
+      if ('type' in value) {
+        try {
+          return await this.resolver.resolve(value as any, context, scope)
+        } catch (error) {
+          if (!(error instanceof Error) || !/Unknown value resolver type/.test(error.message)) {
+            throw error
+          }
+          // fall through to literal handling when resolver type is unknown
+        }
+      }
+
+      const entries = await Promise.all(
+        Object.entries(value).map(async ([key, nested]) => {
+          const resolvedNested = await this.resolveLiteralObject(nested, context, scope)
+          return [key, resolvedNested]
+        })
+      )
+      return Object.fromEntries(entries)
+    }
+
+    return value
   }
 
   /**

--- a/src/lib/core/signer.ts
+++ b/src/lib/core/signer.ts
@@ -1,0 +1,76 @@
+import { ethers } from 'ethers'
+
+export interface DigestSigner extends ethers.Signer {
+  signDigest(digest: Uint8Array | string): Promise<string>
+}
+
+export function isDigestSigner(signer: ethers.Signer): signer is DigestSigner {
+  return typeof (signer as any).signDigest === 'function'
+}
+
+type LegacySignMessage = (message: Uint8Array | string) => Promise<string>
+
+/**
+ * Walk a signer and any wrapped inner signer (e.g. `NonceManager.signer`) applying
+ * `pick` until it returns a value. This lets us reach the underlying key/legacy
+ * method even when the signer has been wrapped (for nonce management, etc.).
+ */
+function unwrap<T>(signer: ethers.Signer, pick: (s: any) => T | undefined): T | undefined {
+  let current: any = signer
+  const seen = new Set<any>()
+  while (current && !seen.has(current)) {
+    seen.add(current)
+    const found = pick(current)
+    if (found !== undefined) {
+      return found
+    }
+    current = current.signer
+  }
+  return undefined
+}
+
+function findSigningKey(signer: ethers.Signer): ethers.SigningKey | undefined {
+  return unwrap(signer, (s) => {
+    if (s.signingKey && typeof s.signingKey.sign === 'function') {
+      return s.signingKey as ethers.SigningKey
+    }
+    if (typeof s.privateKey === 'string' && s.privateKey.length > 0) {
+      return new ethers.SigningKey(s.privateKey)
+    }
+    return undefined
+  })
+}
+
+function findLegacySignMessage(signer: ethers.Signer): LegacySignMessage | undefined {
+  return unwrap(signer, (s) =>
+    typeof s._legacySignMessage === 'function' ? (s._legacySignMessage.bind(s) as LegacySignMessage) : undefined
+  )
+}
+
+export function toDigestSigner(signer: ethers.Signer): DigestSigner {
+  if (isDigestSigner(signer)) {
+    return signer
+  }
+
+  const signingKey = findSigningKey(signer)
+  if (signingKey) {
+    const digestSigner = signer as DigestSigner
+    digestSigner.signDigest = async (digest: Uint8Array | string) => {
+      const bytes = typeof digest === 'string' ? ethers.getBytes(digest) : digest
+      return ethers.Signature.from(signingKey.sign(bytes)).serialized
+    }
+    return digestSigner
+  }
+
+  const legacySignMessage = findLegacySignMessage(signer)
+  if (legacySignMessage) {
+    const digestSigner = signer as DigestSigner
+    digestSigner.signDigest = async (digest: Uint8Array | string) => {
+      const bytes = typeof digest === 'string' ? ethers.getBytes(digest) : digest
+      return legacySignMessage(bytes)
+    }
+    return digestSigner
+  }
+
+  throw new Error(`Signer does not expose a private key. Provide a local signer.`)
+}

--- a/src/lib/types/actions.ts
+++ b/src/lib/types/actions.ts
@@ -88,8 +88,43 @@ export interface AssertAction {
   };
 }
 
+export interface SignDigestAction {
+  type: 'sign-digest';
+  arguments: {
+    digest: BytesValue;
+  };
+}
+
+export interface SignMessageAction {
+  type: 'sign-message';
+  arguments: {
+    message: Value<string | Uint8Array | number[]>;
+  };
+}
+
+export interface SignTypedDataAction {
+  type: 'sign-typed-data';
+  arguments: {
+    domain: Value<Record<string, any>>;
+    types: Value<Record<string, { name: string; type: string }[]>>;
+    message: Value<Record<string, any>>;
+    primaryType?: Value<string>;
+  };
+}
+
 // A union of all primitive action types.
-export type PrimitiveAction = SendTransactionAction | SendSignedTransactionAction | VerifyContractAction | StaticAction | CreateContractAction | TestNicksMethodAction | JsonRequestAction | AssertAction;
+export type PrimitiveAction =
+  | SendTransactionAction
+  | SendSignedTransactionAction
+  | VerifyContractAction
+  | StaticAction
+  | CreateContractAction
+  | TestNicksMethodAction
+  | JsonRequestAction
+  | AssertAction
+  | SignDigestAction
+  | SignMessageAction
+  | SignTypedDataAction;
 
 const primitiveActionTypes = [
   'send-transaction',
@@ -100,6 +135,9 @@ const primitiveActionTypes = [
   'test-nicks-method',
   'json-request',
   'assert',
+  'sign-digest',
+  'sign-message',
+  'sign-typed-data',
 ] as const;
 
 /**


### PR DESCRIPTION
* sign-digest
* sign-message
* sign-typed-data

Also adds a `custom` field to networks so that they can provide any additional data they like (useful for signing specific payloads per chain etc)

Note: ethers :nauseated_face: doesn't expose signDigest so this includes an ugly wrapper. When switch to ox?