### PR TITLE
Add Network.params passthrough and dotted path resolution

### DIFF
--- a/src/lib/__tests__/network-loader.spec.ts
+++ b/src/lib/__tests__/network-loader.spec.ts
@@ -98,3 +98,53 @@ describe('network-loader rpcUrl token replacement', () => {
     expect(networks[0].rpcUrl).toBe('https://node.example.com/')
   })
 })
+
+describe('network-loader params', () => {
+  afterAll(async () => {
+    try {
+      await fs.rm(tmpDir, { recursive: true, force: true })
+    } catch {}
+  })
+
+  test('passes through valid params object', async () => {
+    const projectRoot = path.join(tmpDir, 'params-valid')
+    const yaml = `
+- name: "MyNet"
+  chainId: 4217
+  rpcUrl: "http://127.0.0.1:8545"
+  params:
+    myParam: true
+`
+    await writeNetworksYaml(projectRoot, yaml)
+
+    const networks = await loadNetworks(projectRoot)
+    expect(networks).toHaveLength(1)
+    expect(networks[0].params).toEqual({ myParam: true })
+  })
+
+  test('rejects params when not a plain object', async () => {
+    const projectRoot = path.join(tmpDir, 'params-invalid-array')
+    const yaml = `
+- name: "BadNet"
+  chainId: 1
+  rpcUrl: "http://127.0.0.1:8545"
+  params: [1, 2, 3]
+`
+    await writeNetworksYaml(projectRoot, yaml)
+
+    await expect(loadNetworks(projectRoot)).rejects.toThrow(/Failed to load or parse networks.yaml/)
+  })
+
+  test('rejects params when null', async () => {
+    const projectRoot = path.join(tmpDir, 'params-invalid-null')
+    const yaml = `
+- name: "BadNet"
+  chainId: 1
+  rpcUrl: "http://127.0.0.1:8545"
+  params: null
+`
+    await writeNetworksYaml(projectRoot, yaml)
+
+    await expect(loadNetworks(projectRoot)).rejects.toThrow(/Failed to load or parse networks.yaml/)
+  })
+})

--- a/src/lib/core/__tests__/resolver.spec.ts
+++ b/src/lib/core/__tests__/resolver.spec.ts
@@ -1573,6 +1573,48 @@ describe('ValueResolver', () => {
       })
     })
 
+    describe('Network().params dotted paths', () => {
+      const mockPrivateKey = '0x0000000000000000000000000000000000000000000000000000000000000001'
+
+      it('should default params.myParam to false when params is absent', async () => {
+        const result = await resolver.resolve('{{Network().params.myParam}}', context)
+        expect(result).toBe(false)
+      })
+
+      it('should default params.myParam to false when myParam is absent', async () => {
+        const networkWithParams: Network = { ...mockNetwork, params: {} }
+        const paramsContext = new ExecutionContext(networkWithParams, mockPrivateKey, mockRegistry)
+        try {
+          const result = await resolver.resolve('{{Network().params.myParam}}', paramsContext)
+          expect(result).toBe(false)
+        } finally {
+          await paramsContext.dispose()
+        }
+      })
+
+      it('should return params.myParam when set to true', async () => {
+        const networkWithParams: Network = { ...mockNetwork, params: { myParam: true } }
+        const paramsContext = new ExecutionContext(networkWithParams, mockPrivateKey, mockRegistry)
+        try {
+          const result = await resolver.resolve('{{Network().params.myParam}}', paramsContext)
+          expect(result).toBe(true)
+        } finally {
+          await paramsContext.dispose()
+        }
+      })
+
+      it('should return params.myParam when set to false', async () => {
+        const networkWithParams: Network = { ...mockNetwork, params: { myParam: false } }
+        const paramsContext = new ExecutionContext(networkWithParams, mockPrivateKey, mockRegistry)
+        try {
+          const result = await resolver.resolve('{{Network().params.myParam}}', paramsContext)
+          expect(result).toBe(false)
+        } finally {
+          await paramsContext.dispose()
+        }
+      })
+    })
+
     describe('invalid Network expressions', () => {
       it('should fail for invalid property', async () => {
         await expect(resolver.resolve('{{Network().invalid}}', context))

--- a/src/lib/core/resolver.ts
+++ b/src/lib/core/resolver.ts
@@ -118,20 +118,38 @@ export class ValueResolver {
       return value
     }
 
-    // Check for Network(...) property access
-    const networkMatch = expression.match(/^Network\(\)\.(\w+)$/)
+    // Check for Network() property access (single segment or dotted path)
+    const networkMatch = expression.match(/^Network\(\)\.(.+)$/)
     if (networkMatch) {
-      const [, property] = networkMatch
+      const path = networkMatch[1]
+      const segments = path.split('.')
       const network = context.getNetwork()
-      if (property === 'testnet') {
-        // Special case for testnet property. Default to false if not set.
-        return !!network.testnet
+
+      if (segments.length === 1) {
+        const property = segments[0]
+        if (property === 'testnet') {
+          // Default to false if not set.
+          return !!network.testnet
+        }
+        const value = (network as unknown as Record<string, unknown>)[property]
+        if (value === undefined) {
+          throw new Error(`Property "${property}" does not exist on network`)
+        }
+        return value
       }
-      const value = (network as any)[property]
-      if (value === undefined) {
-        throw new Error(`Property "${property}" does not exist on network`)
+
+      // Dotted paths (e.g. params.myParam): missing keys default to false.
+      let current: unknown = network
+      for (const segment of segments) {
+        if (current === null || current === undefined || typeof current !== 'object') {
+          return false
+        }
+        current = (current as Record<string, unknown>)[segment]
+        if (current === undefined) {
+          return false
+        }
       }
-      return value
+      return current
     }
 
     // Check scope for local variables (template arguments) first

--- a/src/lib/network-loader.ts
+++ b/src/lib/network-loader.ts
@@ -22,7 +22,13 @@ function isValidNetwork(obj: unknown): obj is Network {
     // testnet field is optional and should be a boolean if present
     (!('testnet' in obj) || typeof (obj as Record<string, unknown>).testnet === 'boolean') &&
     // evmVersion field is optional and should be a string if present
-    (!('evmVersion' in obj) || typeof (obj as Record<string, unknown>).evmVersion === 'string')
+    (!('evmVersion' in obj) || typeof (obj as Record<string, unknown>).evmVersion === 'string') &&
+    // params field is optional and must be a plain object if present
+    (!('params' in obj) || (
+      typeof (obj as Record<string, unknown>).params === 'object' &&
+      (obj as Record<string, unknown>).params !== null &&
+      !Array.isArray((obj as Record<string, unknown>).params)
+    ))
   )
 }
 

--- a/src/lib/types/network.ts
+++ b/src/lib/types/network.ts
@@ -25,4 +25,9 @@ export interface Network {
    * "paris", "shanghai", "cancun". Used to filter jobs that require a minimum EVM version.
    */
   evmVersion?: string
+
+  /**
+   * Integrator-owned metadata bag. Keys are not validated by Catapult.
+   */
+  params?: Record<string, unknown>
 }


### PR DESCRIPTION
## Summary

- Add optional `params` bag on `Network` (loaded from `networks.yaml` without validating inner keys).
- Extend `Network()` resolver to support dotted paths (e.g. `{{Network().params.trailsOnly}}`); missing intermediate keys resolve to `false`.
- Add network-loader and resolver unit tests.

## Test plan

- [x] `pnpm test` (network-loader + resolver specs)
- [ ] Publish / bump `@0xsequence/catapult` after merge
- [ ] Wire `params.trailsOnly` in live-contracts `networks.yaml` and job `skip_condition`s


Made with [Cursor](https://cursor.com)