### PR TITLE
feat(provenance): pin build toolchain via source.yaml `image` (run build in Docker)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1019,6 +1019,33 @@ to overwrite them. Both commands clone the configured `repo`, check out `ref` or
 Catapult selects by matching the committed build-info `id`, then by filename; if
 neither is unique, the entry fails with an ambiguity error.
 
+### Pinning the build toolchain with `image`
+
+Because provenance compares the *entire* build-info JSON (including compiler
+settings such as `evmVersion`), the rebuild must use the same toolchain that
+produced the committed file. Add an optional `image` field to run the `build`
+command inside a pinned Docker image instead of on the host:
+
+```yaml
+type: source
+
+build_info:
+  "./stage1.json":
+    repo: "https://github.com/0xsequence/wallet-contracts-v3"
+    commit: "0d9061f229da73edae890e6fdd1fbf753028df6d"
+    image: "ghcr.io/foundry-rs/foundry:v1.5.1"
+    build: "forge build --build-info"
+```
+
+When `image` is set, Catapult runs `docker run <image>` with the checkout
+bind-mounted at `/workspace` (also the working directory and `$HOME`), the build
+command executed via `sh -c`, and — on POSIX hosts — the container running as the
+caller's `uid:gid` so the generated files are owned by you and the temporary
+checkout can be cleaned up. This keeps the toolchain pinned per entry (different
+build-info files can use different images) and leaves the host/runner untouched;
+it requires Docker to be installed and running. The `image` field is also
+supported in per-contract `contracts` overrides.
+
 If a build-info file needs a per-contract override, key it by fully-qualified
 contract name:
 

--- a/src/lib/parsers/__tests__/source.spec.ts
+++ b/src/lib/parsers/__tests__/source.spec.ts
@@ -30,6 +30,37 @@ build_info:
     expect(result!.build_info['./stage1.json'].contracts?.['src/Stage1Module.sol:Stage1Module'].ref).toBe('stage1-special')
   })
 
+  it('should parse the optional image field', () => {
+    const result = parseSourceDocument(`
+type: source
+build_info:
+  "./stage1.json":
+    repo: "https://github.com/0xsequence/wallet-contracts-v3"
+    commit: "0d9061f229da73edae890e6fdd1fbf753028df6d"
+    image: "ghcr.io/foundry-rs/foundry:v1.5.1"
+    build: "forge build --build-info"
+`)
+
+    expect(result).not.toBeNull()
+    expect(result!.build_info['./stage1.json'].image).toBe('ghcr.io/foundry-rs/foundry:v1.5.1')
+  })
+
+  it('should validate that image is a string', () => {
+    const result = parseSourceDocument(`
+type: source
+build_info:
+  "./stage1.json":
+    repo: "https://github.com/0xsequence/wallet-contracts-v3"
+    image: 123
+`)
+
+    expect(result).not.toBeNull()
+    expect(result!.build_info).toEqual({})
+    expect(result!.warnings).toEqual([
+      expect.stringContaining('image')
+    ])
+  })
+
   it('should require repo on each build-info provenance entry', () => {
     const result = parseSourceDocument(`
 type: source
@@ -129,6 +160,18 @@ build_info:
         commit: '0d9061f229da73edae890e6fdd1fbf753028df6d'
       })
       expect(result).not.toHaveProperty('contracts')
+    })
+
+    it('should let a contract override the image', () => {
+      const result = mergeSourceProvenance({
+        repo: 'https://github.com/0xsequence/wallet-contracts-v3',
+        commit: '0d9061f229da73edae890e6fdd1fbf753028df6d',
+        image: 'ghcr.io/foundry-rs/foundry:v1.5.1'
+      }, {
+        image: 'ghcr.io/foundry-rs/foundry:v1.6.0'
+      })
+
+      expect(result.image).toBe('ghcr.io/foundry-rs/foundry:v1.6.0')
     })
   })
 })

--- a/src/lib/parsers/source.ts
+++ b/src/lib/parsers/source.ts
@@ -1,7 +1,7 @@
 import { parse as parseYaml, YAMLParseError } from 'yaml'
 import { BuildInfoSourceProvenance, SourceDocument, SourceProvenance, SourceProvenanceOverride } from '../types'
 
-const STRING_FIELDS = ['repo', 'ref', 'commit', 'build'] as const
+const STRING_FIELDS = ['repo', 'ref', 'commit', 'build', 'image'] as const
 const BUILD_INFO_FIELDS = new Set<string>([...STRING_FIELDS, 'contracts'])
 const CONTRACT_OVERRIDE_FIELDS = new Set<string>(STRING_FIELDS)
 

--- a/src/lib/provenance.ts
+++ b/src/lib/provenance.ts
@@ -272,7 +272,7 @@ async function buildFromSourceProvenance(provenance: BuildInfoSourceProvenance):
     }
 
     const head = await gitStdout(['rev-parse', 'HEAD'], checkoutDir)
-    await runShell(provenance.build, checkoutDir)
+    await runBuild(provenance.build, checkoutDir, provenance.image)
     const candidates = await findBuildInfoCandidates(checkoutDir)
 
     if (candidates.length === 0) {
@@ -525,6 +525,77 @@ async function checkoutGitCommit(commit: string, cwd: string): Promise<void> {
   await runGit(['checkout', '--detach', commit], cwd)
 }
 
+/**
+ * Runs a provenance build command. When `image` is set the command runs inside
+ * `docker run <image>` with the checkout bind-mounted, so the build toolchain is
+ * pinned per source entry and nothing on the host/runner is mutated. Otherwise it
+ * runs directly on the host shell.
+ */
+async function runBuild(command: string, cwd: string, image?: string): Promise<void> {
+  if (image) {
+    await runDockerBuild(command, cwd, image)
+  } else {
+    await runShell(command, cwd)
+  }
+}
+
+const CONTAINER_WORKDIR = '/workspace'
+
+/**
+ * Runs the build command inside a container. The checkout is mounted at
+ * `/workspace` and used as the working directory; `HOME` points there too so
+ * toolchains that cache to `$HOME` (e.g. solc downloads) write into the
+ * (disposable) checkout. On POSIX the container runs as the host uid:gid so the
+ * generated build-info is owned by the caller and the temp checkout can be read
+ * back and cleaned up. The image's entrypoint is overridden with `sh -c` so the
+ * build string is interpreted the same way regardless of the image.
+ */
+async function runDockerBuild(command: string, cwd: string, image: string): Promise<void> {
+  const args = [
+    'run',
+    '--rm',
+    '-v',
+    `${cwd}:${CONTAINER_WORKDIR}`,
+    '-w',
+    CONTAINER_WORKDIR,
+    '-e',
+    `HOME=${CONTAINER_WORKDIR}`
+  ]
+
+  const uid = typeof process.getuid === 'function' ? process.getuid() : undefined
+  const gid = typeof process.getgid === 'function' ? process.getgid() : undefined
+  if (uid !== undefined && gid !== undefined) {
+    args.push('--user', `${uid}:${gid}`)
+  }
+
+  args.push('--entrypoint', 'sh', image, '-c', command)
+
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn('docker', args, {
+      cwd,
+      env: process.env,
+      stdio: 'inherit'
+    })
+
+    child.on('error', error => {
+      reject(
+        new Error(
+          `failed to start docker for image "${image}" (is Docker installed and running?): ${error.message}`
+        )
+      )
+    })
+    child.on('exit', (code, signal) => {
+      if (code === 0) {
+        resolve()
+      } else if (signal) {
+        reject(new Error(`build command failed: terminated by ${signal}`))
+      } else {
+        reject(new Error(`build command failed: exited with code ${code}`))
+      }
+    })
+  })
+}
+
 async function runShell(command: string, cwd: string): Promise<void> {
   await new Promise<void>((resolve, reject) => {
     const child = spawn(command, {
@@ -586,7 +657,8 @@ function buildCacheKey(provenance: BuildInfoSourceProvenance): string {
     repo: provenance.repo,
     ref: provenance.ref,
     commit: provenance.commit,
-    build: provenance.build
+    build: provenance.build,
+    image: provenance.image
   })
 }
 

--- a/src/lib/types/source.ts
+++ b/src/lib/types/source.ts
@@ -3,6 +3,13 @@ export interface SourceProvenance {
   ref?: string
   commit?: string
   build?: string
+  /**
+   * Optional Docker image to run the `build` command inside. When set, Catapult
+   * executes the build in `docker run <image>` with the checkout mounted, instead
+   * of running it directly on the host. This pins the build toolchain per entry
+   * and keeps the host/runner untouched.
+   */
+  image?: string
   sourceDocumentPath?: string
   buildInfoPath?: string
 }
@@ -12,6 +19,7 @@ export interface SourceProvenanceOverride {
   ref?: string
   commit?: string
   build?: string
+  image?: string
 }
 
 export interface BuildInfoSourceProvenance extends SourceProvenance {


### PR DESCRIPTION
## What

Adds an optional **`image`** field to `source.yaml` provenance entries. When set, Catapult runs the entry's `build` command inside `docker run <image>` instead of on the host.

```yaml
type: source
build_info:
  "./stage1.json":
    repo: "https://github.com/0xsequence/wallet-contracts-v3"
    commit: "0d9061f229da73edae890e6fdd1fbf753028df6d"
    image: "ghcr.io/foundry-rs/foundry:v1.5.1"   # <-- new
    build: "forge build --build-info"
```

## Why

`provenance verify` compares the **entire** normalized build-info JSON, including compiler settings such as `settings.evmVersion`. So the rebuild must use the *same toolchain* that produced the committed file — otherwise a drifting default fails the compare. (Concretely: Foundry's default EVM target moved `prague` → `osaka` between stable and nightly, which silently broke a verify whose committed artifact was `prague`.)

Until now the only way to pin the toolchain was to bake the whole `docker run …` invocation into each entry's `build` string — verbose, easy to get the mount/user/HOME flags wrong, and duplicated across every entry. The toolchain is really a property of the build, so Catapult should own that plumbing.

## Behavior

When `image` is set, the build runs in a container with:
- the checkout bind-mounted at `/workspace` (also the working directory and `$HOME`, so toolchains that cache to `$HOME` — e.g. solc downloads — write into the disposable checkout);
- the build string executed via `sh -c` (entrypoint overridden, so it's image-agnostic);
- on POSIX hosts, `--user <uid>:<gid>` so generated build-info is owned by the caller and the temp checkout can be read back and cleaned up.

This keeps the toolchain pinned **per entry** (different build-info files can use different images), leaves the host/runner untouched, and requires only that Docker be installed and running. `image` is also honored in per-contract `contracts` overrides. When `image` is omitted, behavior is unchanged (build runs on the host shell).

## Changes

- `types/source`: `image?: string` on `SourceProvenance` + `SourceProvenanceOverride`
- `parsers/source`: validate `image` as a string field (also in contract overrides)
- `provenance`: `runBuild()` dispatches to `runDockerBuild()` when `image` is set; `image` added to the build cache key
- Tests (parser: parse / validate / override-merge) + README section

All 676 existing tests pass; the new docker path is intentionally not exercised in unit tests (would require Docker on the runner) — it's validated end-to-end against a real project.
